### PR TITLE
fomatto adds escapes custom format string when using key

### DIFF
--- a/lib/fomatto.js
+++ b/lib/fomatto.js
@@ -25,6 +25,7 @@
 
     // match {} placholders like {0}, {name}, {} and the inner "{{foo}}"
     // { and } can be escaped with \
+
     var matchExp = /([^\\]|^)\{([^\{\}]+[^\\\}]|[^\{\\\}]|)\}/g,
 
         // match escaped curly braces
@@ -67,6 +68,7 @@
                     // Strip the format syntax from the key
                     if (!formatList.length) {
                         key = string.substring(0, f.index);
+                        string = string.substring(key.length - 1);
                     }
                     string = string.substring(f[0].length - 1);
                     formatList.push(f);

--- a/test/test.js
+++ b/test/test.js
@@ -334,6 +334,16 @@ exports.testFormattingArgs = function(test) {
     test.done();
 };
 
+exports.testFormattingArgsWithProperty = function(test) {
+    var custom = Formatter({
+        JSON: JSON.stringify
+    });
+    test.equal(custom('({:JSON})', [1,2,3]), '([1,2,3])');
+    test.equal(custom('({property:JSON})', {property: [1,2,3] }), '([1,2,3])');
+    test.done();
+};
+
+
 exports.testFormattingJoin = function(test) {
     test.expect(5);
     test.equals(format('{:join(" ")}', ['blue', 'red', 'green', 'yellow']),

--- a/test/test.js
+++ b/test/test.js
@@ -334,12 +334,22 @@ exports.testFormattingArgs = function(test) {
     test.done();
 };
 
-exports.testFormattingArgsWithProperty = function(test) {
+exports.testFormattingWithProperty = function(test) {
     var custom = Formatter({
         JSON: JSON.stringify
     });
     test.equal(custom('({:JSON})', [1,2,3]), '([1,2,3])');
     test.equal(custom('({property:JSON})', {property: [1,2,3] }), '([1,2,3])');
+    test.done();
+};
+
+exports.testFormattingCalledJustOnce = function(test) {
+    var called = 0;
+    var custom = Formatter({
+        JSON: function (value) { called ++; return JSON.stringify(value) }
+    });
+    custom('({property:JSON})', {property: [1,2,3] })
+    test.equal(called, 1)
     test.done();
 };
 


### PR DESCRIPTION
hey, this library is awesome!

I found this bug and added a failing test:

when using a named property with a custom formatter, the result gets escaped.

``` js
>var custom = Formatter({JSON: JSON.stringify});
>custom('({property:JSON})', {property: [1,2,3] })
'("[1,2,3]")' 
```

the quotes should not have been added.

cheers, Dominic
