### PR TITLE
Tweaking the exports to play nicely with r.js

### DIFF
--- a/lib/fomatto.js
+++ b/lib/fomatto.js
@@ -273,8 +273,9 @@
     FormatError.prototype = new Error();
 
     // Exports
-    exports.Formatter = Formatter;
-    exports.FormatError = FormatError;
+    var exp = typeof window === 'undefined' ? exports || this : window;
+    exp.Formatter = Formatter;
+    exp.FormatError = FormatError;
 
 })(typeof exports !== 'undefined' ? exports : window);
 


### PR DESCRIPTION
When we optimize our client for production we send the relevant js files to r.js (https://github.com/jrburke/r.js) for optimization. Within this environment neither exports nor window are available instead we use this to export.
