### PR TITLE
Fix capitalization in git URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     
     "repository": {
         "type" : "git",
-        "url" : "http://github.com/BonsaiDen/fomatto.git"
+        "url" : "http://github.com/BonsaiDen/Fomatto.git"
     },
 
     "bugs": {


### PR DESCRIPTION
Github clone URLs are case sensitive. This patch updates package.json to use the correct capitalization for the git repository URL.

```
$ git clone http://github.com/BonsaiDen/fomatto.git
Cloning into 'fomatto'...
Username for 'http://github.com': ^C
$ git clone http://github.com/BonsaiDen/Fomatto.git
Cloning into 'Fomatto'...
remote: Counting objects: 314, done.
remote: Compressing objects: 100% (129/129), done.
remote: Total 314 (delta 151), reused 310 (delta 148)
Receiving objects: 100% (314/314), 61.69 KiB, done.
Resolving deltas: 100% (151/151), done.
```
